### PR TITLE
Allow Mixed Filter Types

### DIFF
--- a/lib/ipfilter.js
+++ b/lib/ipfilter.js
@@ -51,8 +51,6 @@ module.exports = function ipfilter(ips, opts) {
         errorCode: 401,
         errorMessage: 'Unauthorized',
         allowPrivateIPs: false,
-        cidr: false,
-        ranges: false,
         excluding: []
     });
 
@@ -71,7 +69,7 @@ module.exports = function ipfilter(ips, opts) {
         if (!ipAddress) {
             ipAddress = req.connection.remoteAddress;
         }
-        if(cloudFlareConnectingIp!=undefined){
+        if(cloudFlareConnectingIp !== undefined){
             ipAddress=cloudFlareConnectingIp;
         }
 
@@ -87,49 +85,70 @@ module.exports = function ipfilter(ips, opts) {
     };
 
     var matchClientIp = function(ip){
-        var mode = settings.mode.toLowerCase(),
-            allowedIp = false,
-            notBannedIp = false,
-            isPrivateIpOkay = false; // Normalize mode
+        var mode = settings.mode.toLowerCase();
 
-        if(settings.cidr){
-            for(var i = 0; i < ips.length; i++){
+        var result = _.invoke(ips,testIp,ip,mode);
 
-                var block = new Netmask(ips[i]);
-
-                if(block.contains(ip)){
-                    allowedIp = (mode === 'allow');
-                    if(mode === 'deny'){
-                        notBannedIp = false;
-                    }
-                    break;
-                }else{
-                    notBannedIp = (mode === 'deny');
-                    isPrivateIpOkay = settings.allowPrivateIPs && iputil.isPrivate(ip);
-                }
-            }
-        }else if(settings.ranges){
-            var filteredSet = _.filter(ips,function(ipSet){
-                if(ipSet.length > 1){
-                    var startIp = iputil.toLong(ipSet[0]);
-                    var endIp = iputil.toLong(ipSet[1]);
-                    var longIp = iputil.toLong(ip);
-                    return  longIp >= startIp && longIp <= endIp;
-                }else{
-                    return ip === ipSet[0];
-                }
-            });
-
-            allowedIp = (mode === 'allow' && filteredSet.length > 0);
-            notBannedIp = (mode === 'deny' && filteredSet.length === 0);
-            isPrivateIpOkay = settings.allowPrivateIPs && iputil.isPrivate(ip) && !(mode === 'deny' && filteredSet.length > 0);
+        if(mode === 'allow'){
+            return _.some(result);
         }else{
-            allowedIp = (mode === 'allow' && ips.indexOf(ip) !== -1);
-            notBannedIp = (mode === 'deny' && ips.indexOf(ip) === -1);
-            isPrivateIpOkay = settings.allowPrivateIPs && iputil.isPrivate(ip) && !(mode === 'deny' && ips.indexOf(ip) !== -1);
+            return _.every(result);
+        }
+    };
+
+    var testIp = function(ip,mode){
+        var constraint = this;
+
+        // Check if it is an array or a string
+        if(typeof constraint === 'string'){
+            var cidrRegex = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))$/;
+            if(cidrRegex.test(constraint)){
+                return testCidrBlock(ip,constraint,mode);
+            }else{
+                return testExplicitIp(ip,constraint,mode);
+            }
         }
 
-        return allowedIp || notBannedIp || isPrivateIpOkay;
+        if(typeof constraint === 'object'){
+            return testRange(ip,constraint,mode);
+        }
+    };
+
+    var testExplicitIp = function(ip,constraint,mode){
+        if(ip === constraint){
+            return mode === 'allow';
+        }else{
+            return mode === 'deny';
+        }
+    };
+
+    var testCidrBlock = function(ip,constraint,mode){
+        var block = new Netmask(constraint);
+
+        if(block.contains(ip)){
+            return mode === 'allow';
+        }else{
+            return mode === 'deny';
+        }
+    };
+
+    var testRange = function(ip,constraint,mode){
+        var filteredSet = _.filter(ips,function(constraint){
+            if(constraint.length > 1){
+                var startIp = iputil.toLong(constraint[0]);
+                var endIp = iputil.toLong(constraint[1]);
+                var longIp = iputil.toLong(ip);
+                return  longIp >= startIp && longIp <= endIp;
+            }else{
+                return ip === constraint[0];
+            }
+        });
+
+        if(filteredSet.length > 0){
+            return mode === 'allow';
+        }else{
+            return mode === 'deny';
+        }
     };
 
     return function(req, res, next) {

--- a/test.js
+++ b/test.js
@@ -120,7 +120,7 @@ describe('using cidr block',function(){
     describe('enforcing whitelist restrictions',function(){
         beforeEach(function(){
             // Ip range: 127.0.0.1 - 127.0.0.14
-            this.ipfilter = ipfilter([ '127.0.0.1/28' ], { cidr: true, log: false, mode: 'allow' });
+            this.ipfilter = ipfilter([ '127.0.0.1/28' ], { log: false, mode: 'allow' });
             this.req = {
                 session: {},
                 headers: [],
@@ -172,7 +172,7 @@ describe('using cidr block',function(){
     describe('enforcing IP address blacklist restrictions', function(){
 
         beforeEach(function(){
-            this.ipfilter = ipfilter([ '127.0.0.1/28' ], { cidr: true, log: false });
+            this.ipfilter = ipfilter([ '127.0.0.1/28' ], { log: false });
             this.req = {
                 session: {},
                 headers: [],
@@ -223,7 +223,7 @@ describe('using cidr block',function(){
 
     describe('enforcing private ip restrictions',function(){
         beforeEach(function(){
-            this.ipfilter = ipfilter([ '127.0.0.1/28' ], { cidr: true, log: false, allowPrivateIPs: true });
+            this.ipfilter = ipfilter([ '127.0.0.1/28' ], { log: false, allowPrivateIPs: true });
             this.req = {
                 session: {},
                 headers: [],
@@ -246,7 +246,7 @@ describe('using ranges',function(){
     describe('enforcing whitelist restrictions',function(){
         beforeEach(function(){
             // Ip range: 127.0.0.1 - 127.0.0.14
-            this.ipfilter = ipfilter([ ['127.0.0.1','127.0.0.3'] ], { ranges: true, log: false, mode: 'allow' });
+            this.ipfilter = ipfilter([ ['127.0.0.1','127.0.0.3'] ], { log: false, mode: 'allow' });
             this.req = {
                 session: {},
                 headers: [],
@@ -305,7 +305,7 @@ describe('using ranges',function(){
     describe('enforcing ip restrictions with only one ip in the range',function(){
         beforeEach(function(){
             // Ip range: 127.0.0.1 - 127.0.0.14
-            this.ipfilter = ipfilter([ ['127.0.0.1'] ], { ranges: true, log: false, mode: 'allow' });
+            this.ipfilter = ipfilter([ ['127.0.0.1'] ], { log: false, mode: 'allow' });
             this.req = {
                 session: {},
                 headers: [],
@@ -338,7 +338,7 @@ describe('using ranges',function(){
     describe('enforcing IP address blacklist restrictions', function(){
 
         beforeEach(function(){
-            this.ipfilter = ipfilter([ ['127.0.0.1','127.0.0.3'] ], { ranges: true, log: false });
+            this.ipfilter = ipfilter([ ['127.0.0.1','127.0.0.3'] ], { log: false });
             this.req = {
                 session: {},
                 headers: [],
@@ -389,7 +389,7 @@ describe('using ranges',function(){
 
     describe('enforcing private ip restrictions',function(){
         beforeEach(function(){
-            this.ipfilter = ipfilter([ ['127.0.0.1','127.0.0.3'] ], { ranges: true, log: false, allowPrivateIPs: true });
+            this.ipfilter = ipfilter([ ['127.0.0.1','127.0.0.3'] ], { log: false, allowPrivateIPs: true });
             this.req = {
                 session: {},
                 headers: [],
@@ -528,7 +528,7 @@ describe('external logger function', function () {
 describe('an array of cidr blocks',function(){
     describe('blacklist',function(){
         beforeEach(function(){
-            this.ipfilter = ipfilter(['72.30.0.0/26', '127.0.0.1/24'], { cidr: true, mode: 'deny', log: false });
+            this.ipfilter = ipfilter(['72.30.0.0/26', '127.0.0.1/24'], { mode: 'deny', log: false });
             this.req = {
                 session: {},
                 headers: [],
@@ -553,7 +553,7 @@ describe('an array of cidr blocks',function(){
 
     describe('whitelist',function(){
         beforeEach(function(){
-            this.ipfilter = ipfilter(['72.30.0.0/26', '127.0.0.1/24'], { cidr: true, mode: 'allow', log: false });
+            this.ipfilter = ipfilter(['72.30.0.0/26', '127.0.0.1/24'], { mode: 'allow', log: false });
             this.req = {
                 session: {},
                 headers: [],
@@ -573,7 +573,7 @@ describe('an array of cidr blocks',function(){
 });
 
 describe('mixing different types of filters',function(){
-    describe('whitelist', function () {
+    describe('with a whitelist', function () {
         beforeEach(function(){
             this.ipfilter = ipfilter(['127.0.0.1', '192.168.1.3/28', ['127.0.0.3', '127.0.0.35']], { cidr: true, mode: 'allow', log: false });
             this.req = {
@@ -607,9 +607,9 @@ describe('mixing different types of filters',function(){
         });
     });
 
-    describe('blacklist', function(){
+    describe('with a blacklist', function(){
         beforeEach(function(){
-            this.ipfilter = ipfilter(['127.0.0.1', '192.168.1.3/28', ['127.0.0.3', '127.0.0.35']], { cidr: true, ranges: true, mode: 'deny', log: false });
+            this.ipfilter = ipfilter(['127.0.0.1', '192.168.1.3/28', ['127.0.0.3', '127.0.0.35']], { mode: 'deny', log: false });
             this.req = {
                 session: {},
                 headers: [],


### PR DESCRIPTION
This will allow the use of mixed filter types.  So for example you can use explicit IP addresses, ranges, and CIDR blocks all in the same array.

It also removes the need to specify what kind of filter you are using.  It will detect which filter type you are using.

## Issues

* #12 