### PR TITLE
Implement redirect option

### DIFF
--- a/lib/ipfilter.js
+++ b/lib/ipfilter.js
@@ -50,6 +50,7 @@ module.exports = function ipfilter(ips, opts) {
     mode: 'deny',
     log: true,
     logF: logger,
+    redirect: null,
     errorCode: 401,
     errorMessage: 'Unauthorized',
     allowPrivateIPs: false,
@@ -183,6 +184,10 @@ module.exports = function ipfilter(ips, opts) {
         if (settings.log) {
           logger('Access granted for excluded path: ' + results[0]);
         }
+        if(settings.redirect){
+          res.statusCode = settings.errorCode;
+          return res.sendFile(settings.redirect);
+        }
         return next();
       }
     }
@@ -199,13 +204,20 @@ module.exports = function ipfilter(ips, opts) {
       if (settings.log) {
         settings.logF('Access granted to IP address: ' + ip);
       }
-
+      if(settings.redirect){
+        res.statusCode = settings.errorCode;
+        return res.sendFile(settings.redirect);
+      }
       return next();
     }
 
     // Deny access
     if (settings.log) {
       settings.logF('Access denied to IP address: ' + ip);
+    }
+    if(settings.redirect){
+      res.statusCode = settings.errorCode;
+      return res.sendFile(settings.redirect);
     }
 
     res.statusCode = settings.errorCode;

--- a/lib/ipfilter.js
+++ b/lib/ipfilter.js
@@ -184,7 +184,7 @@ module.exports = function ipfilter(ips, opts) {
         if (settings.log) {
           logger('Access granted for excluded path: ' + results[0]);
         }
-        if(settings.redirect){
+        if (settings.redirect && req.accepts('html')) {
           res.statusCode = settings.errorCode;
           return res.sendFile(settings.redirect);
         }
@@ -204,7 +204,7 @@ module.exports = function ipfilter(ips, opts) {
       if (settings.log) {
         settings.logF('Access granted to IP address: ' + ip);
       }
-      if(settings.redirect){
+      if (settings.redirect && req.accepts('html')) {
         res.statusCode = settings.errorCode;
         return res.sendFile(settings.redirect);
       }
@@ -215,7 +215,7 @@ module.exports = function ipfilter(ips, opts) {
     if (settings.log) {
       settings.logF('Access denied to IP address: ' + ip);
     }
-    if(settings.redirect){
+    if (settings.redirect && req.accepts('html')) {
       res.statusCode = settings.errorCode;
       return res.sendFile(settings.redirect);
     }


### PR DESCRIPTION
It may be useful to send a denied user a separate file – perhaps a stylized .html file with embedded css, or a text file with more extrapolation on the cause of the ban.

When a user is denied,

1. Check if a redirect option is defined
2. Apply statusCode
3. Send the file, which inherently terminates

This circumvents the application of errorMessage.

res.sendFile is used instead of res.redirect...
GET '/' -> Banned? -> redirect GET '/403.html' -> Banned? -> redirect GET ...
res.sendFile fixes this by terminating as soon as the file is sent.

res.sendFile requires an absolute path, so to specify a redirect,
```
app.use(ipfilter(blacklist, {
    log: false,
    redirect: __dirname + '/public/403.html',
    errorCode: 403
}));
```

**Passing** `npm test` with 62 passing –  see a [pastebin](http://pastebin.com/4VWaSyXv) of the test.

For future commits, let's incorporate the functionality into the docs, and update ipfilter.js.map (I don't have the compiler on my system right now).