### PR TITLE
add ability to use last value from IP header instead of first

### DIFF
--- a/lib/ipfilter.js
+++ b/lib/ipfilter.js
@@ -55,7 +55,8 @@ module.exports = function ipfilter(ips, opts) {
     logF: logger,
     allowedHeaders: [],
     allowPrivateIPs: false,
-    excluding: []
+    excluding: [],
+    allowedHeadersUseLast: false,
   });
 
   var getClientIp = function getClientIp(req) {
@@ -72,7 +73,10 @@ module.exports = function ipfilter(ips, opts) {
 
     if (headerIp) {
       var splitHeaderIp = headerIp.split(',');
-      ipAddress = splitHeaderIp[0];
+      if (settings.allowedHeadersUseLast)
+        ipAddress = splitHeaderIp[splitHeaderIp.length-1];
+      else
+        ipAddress = splitHeaderIp[0];
     }
 
     if (!ipAddress) {


### PR DESCRIPTION
I was just in a situation were I needed to use the IP that my ELB added to the x-forwarded-for header so I had to change the code a bit. I wanted to add this as a feature.