### PR TITLE
set status/statusCode to 403

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package provides easy IP based access control. This can be achieved either 
 [![Circle CI](https://circleci.com/gh/baminteractive/express-ipfilter/tree/master.svg?style=svg)](https://circleci.com/gh/baminteractive/express-ipfilter/tree/master)
 
 ## Version
-0.2.4
+0.2.5
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ This will run `eslint`,`babel`, and `mocha` and output coverage data into `cover
 
 ## Changelog
 
+0.3.0
+* Added fields `status` and `statusCode` to the IpDeniedError object, which both equal `403`.
+
 0.2.4
 * For IPv4 addresses that have a port (as experienced with Azure web apps), the port is now stripped before comparing it with the contents of the whitelist or blacklist. Fixes issue #49.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express-ipfilter",
   "description": "A light-weight IP address based filtering system",
-  "version": "0.3.0",
+  "version": "0.2.5",
   "author": "BaM Interactive",
   "dependencies": {
     "ip": "~1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "express-ipfilter",
   "description": "A light-weight IP address based filtering system",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "author": "BaM Interactive",
   "dependencies": {
     "ip": "~1.1.0",

--- a/src/deniedError.js
+++ b/src/deniedError.js
@@ -3,6 +3,7 @@ module.exports = function IpDeniedError(message, extra) {
   this.name = this.constructor.name;
   this.message = message || 'The requesting IP was denied';
   this.extra = extra;
+  this.status = this.statusCode = 403;
 };
 
 require('util').inherits(module.exports, Error);


### PR DESCRIPTION
By default, express will [look for these two fields](https://github.com/pillarjs/finalhandler/blob/master/index.js#L197) on the Error object. We should set them to 403, to ensure apps don't default to responding with a 500.